### PR TITLE
Update UpgradeSchema.php

### DIFF
--- a/Setup/UpgradeSchema.php
+++ b/Setup/UpgradeSchema.php
@@ -165,7 +165,7 @@ class UpgradeSchema implements UpgradeSchemaInterface // @codingStandardsIgnoreL
             )->addColumn(
                 'manifest_vcl',
                 \Magento\Framework\DB\Ddl\Table::TYPE_TEXT,
-                \Magento\Framework\DB\Ddl\Table::DEFAULT_TEXT_SIZE,
+                \Magento\Framework\DB\Ddl\Table::MAX_TEXT_SIZE,
                 ['nullable' => false],
                 'Manifest VCL'
             )->addColumn(


### PR DESCRIPTION
This will correct a problem where the module_vcl field truncates VCL larger than 65,535 bytes, the default size of a MySQL "text" field type. Changing this will create the field as a longtext field instead.